### PR TITLE
Add null check when checking animation's joint count

### DIFF
--- a/src/J3D/Data/J3DModelInstance.cpp
+++ b/src/J3D/Data/J3DModelInstance.cpp
@@ -262,7 +262,7 @@ bool J3DModelInstance::CheckUseInstanceTextures() {
 }
 
 void J3DModelInstance::SetJointAnimation(std::shared_ptr<J3DAnimation::J3DJointAnimationInstance> anim) {
-    if (anim->GetJointCount() != mModelData->GetJointCount()) {
+    if (anim != nullptr && anim->GetJointCount() != mModelData->GetJointCount()) {
         return;
     }
 
@@ -270,7 +270,7 @@ void J3DModelInstance::SetJointAnimation(std::shared_ptr<J3DAnimation::J3DJointA
 }
 
 void J3DModelInstance::SetJointFullAnimation(std::shared_ptr<J3DAnimation::J3DJointFullAnimationInstance> anim) {
-    if (anim->GetJointCount() != mModelData->GetJointCount()) {
+    if (anim != nullptr && anim->GetJointCount() != mModelData->GetJointCount()) {
         return;
     }
 


### PR DESCRIPTION
Once a BCK has been loaded on a model instance, it seems to always take precedence over the BCA loaded on that instance, even if the BCA is loaded after, so there's no way to view the BCA anymore. This could be fixed by setting the BCK to null when loading a BCA, but currently that crashes on `anim->GetJointCount()` because `anim` is null.

This change should allow unloading joint animations by setting them to null like other animation types.