### PR TITLE
Fix missing <atomic> include to J3DMaterial.hpp

### DIFF
--- a/include/J3D/Material/J3DMaterial.hpp
+++ b/include/J3D/Material/J3DMaterial.hpp
@@ -8,6 +8,7 @@
 #include <string>
 #include <vector>
 #include <memory>
+#include <atomic>
 
 class GXShape;
 


### PR DESCRIPTION
I encountered a compilation issue when building the library with clang-cl version 20.1.7 where the compiler failed to resolve `std::atomic` in `J3DMaterial.hpp` due to a missing include directive.

Adding `#include <atomic>` to `J3DMaterial.hpp` resolves the issue and ensures compatibility with Clang-based toolchains. This change should have no effect on other compilers that implicitly allow this usage, but it improves standards compliance and portability.